### PR TITLE
20211129_sim_vehicle_param

### DIFF
--- a/selfdrive/car/__init__.py
+++ b/selfdrive/car/__init__.py
@@ -13,8 +13,8 @@ def gen_empty_fingerprint():
 # FIXME: hardcoding honda civic 2016 touring params so they can be used to
 # scale unknown params for other cars
 class CivicParams:
-  MASS = 1326. + STD_CARGO_KG
-  WHEELBASE = 2.70
+  MASS = 9100. + STD_CARGO_KG
+  WHEELBASE = 3.807
   CENTER_TO_FRONT = WHEELBASE * 0.4
   CENTER_TO_REAR = WHEELBASE - CENTER_TO_FRONT
   ROTATIONAL_INERTIA = 2500

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -85,7 +85,7 @@ class CarInterface(CarInterfaceBase):
       ret.mass = CivicParams.MASS
       ret.wheelbase = CivicParams.WHEELBASE
       ret.centerToFront = CivicParams.CENTER_TO_FRONT
-      ret.steerRatio = 15.38  # 10.93 is end-to-end spec
+      ret.steerRatio = 22.15  # 10.93 is end-to-end spec
       if eps_modified:
         # stock request input values:     0x0000, 0x00DE, 0x014D, 0x01EF, 0x0290, 0x0377, 0x0454, 0x0610, 0x06EE
         # stock request output values:    0x0000, 0x0917, 0x0DC5, 0x1017, 0x119F, 0x140B, 0x1680, 0x1680, 0x1680

--- a/tools/sim/bridge.py
+++ b/tools/sim/bridge.py
@@ -29,7 +29,7 @@ args = parser.parse_args()
 W, H = 1164, 874
 REPEAT_COUNTER = 5
 PRINT_DECIMATION = 100
-STEER_RATIO = 15.
+STEER_RATIO = 22.15
 
 pm = messaging.PubMaster(['roadCameraState', 'sensorEvents', 'can', "gpsLocationExternal"])
 sm = messaging.SubMaster(['carControl','controlsState'])
@@ -187,7 +187,8 @@ def bridge(q):
 
   world_map = world.get_map()
 
-  vehicle_bp = blueprint_library.filter('vehicle.tesla.*')[1]
+  #vehicle_bp = blueprint_library.filter('vehicle.tesla.*')[1]
+  vehicle_bp = blueprint_library.find('vehicle.tesla.cybertruck')
   spawn_points = world_map.get_spawn_points()
   assert len(spawn_points) > args.num_selected_spawn_point, \
     f'''No spawn point {args.num_selected_spawn_point}, try a value between 0 and
@@ -198,20 +199,32 @@ def bridge(q):
   max_steer_angle = vehicle.get_physics_control().wheels[0].max_steer_angle
 
   # make tires less slippery
-  # wheel_control = carla.WheelPhysicsControl(tire_friction=5)
+  wheel_control = carla.WheelPhysicsControl(tire_friction=3.5, max_brake_torque=4000.0, radius=38.3500000, max_steer_angle=35.0)
   physics_control = vehicle.get_physics_control()
-  physics_control.mass = 2326
-  # physics_control.wheels = [wheel_control]*4
-  physics_control.torque_curve = [[20.0, 500.0], [5000.0, 500.0]]
+  physics_control.mass = 9100
+  physics_control.wheels = [wheel_control]*4
+  physics_control.torque_curve = [[20.0, 350.0], [5000.0, 350.0]]
   physics_control.gear_switch_time = 0.0
   vehicle.apply_physics_control(physics_control)
+
+  mass = vehicle.get_physics_control().mass
+  wheels = vehicle.get_physics_control().wheels[0]
+  brake_torque = vehicle.get_physics_control().wheels[0].max_brake_torque
+  friction = vehicle.get_physics_control().wheels[0].tire_friction
+  wheel0 = vehicle.get_physics_control().wheels[0].position
+  wheel1 = vehicle.get_physics_control().wheels[1].position
+  wheel2 = vehicle.get_physics_control().wheels[2].position
+  wheel3 = vehicle.get_physics_control().wheels[3].position
+  print("Vehicle:", physics_control)
+  print("Wheels:", wheels)
 
   blueprint = blueprint_library.find('sensor.camera.rgb')
   blueprint.set_attribute('image_size_x', str(W))
   blueprint.set_attribute('image_size_y', str(H))
   blueprint.set_attribute('fov', '70')
   blueprint.set_attribute('sensor_tick', '0.05')
-  transform = carla.Transform(carla.Location(x=0.8, z=1.13))
+  #transform = carla.Transform(carla.Location(x=0.8, z=1.13))
+  transform = carla.Transform(carla.Location(x=1.2, z=2.13))
   camera = world.spawn_actor(blueprint, transform, attach_to=vehicle)
   camera.listen(cam_callback)
 


### PR DESCRIPTION
# Description
Fixed the vehicle param both in Carla simulator and openpilot to more similar to target vehicle (for now is K6A)
There are two parts for param

## For Carla simulator
The `bridge.py` would connect to Carla and load the map, create the actor of set vehicle model...etc
So the modifications in `bridge.py` config the vehicle in Carla. The API of Carla configuration is [here](https://carla.readthedocs.io/en/latest/python_api/).
We use cybertruck model because of the wheelbase (3807mm) is similar to target vehicle.
The other vehicle models could be check by [Carla_bp_library](https://github.com/carla-simulator/carla/blob/d23f3dc1340e47265eeea2b1b33b2d3a2d6d4f42/Docs/bp_library.md) in the `vehicle` section.

## For Openpilot
The modifications in `selfdrive/` are related to openpilot calculation. Adjust those param to make the vehicle drive smooth in Simulator and more fit to target vehicle. 