### PR TITLE
fix(webcam): fixed cv transformations for Logitech c930 webcam

### DIFF
--- a/selfdrive/camerad/cameras/camera_webcam.cc
+++ b/selfdrive/camerad/cameras/camera_webcam.cc
@@ -19,8 +19,8 @@
 #include "selfdrive/common/util.h"
 
 // id of the video capturing device
-const int ROAD_CAMERA_ID = util::getenv("ROADCAM_ID", 1);
-const int DRIVER_CAMERA_ID = util::getenv("DRIVERCAM_ID", 2);
+const int ROAD_CAMERA_ID = util::getenv("ROADCAM_ID", 4);
+const int DRIVER_CAMERA_ID = util::getenv("DRIVERCAM_ID", 0);
 
 #define FRAME_WIDTH  1164
 #define FRAME_HEIGHT 874
@@ -100,16 +100,22 @@ static void road_camera_thread(CameraState *s) {
   set_thread_name("webcam_road_camera_thread");
 
   cv::VideoCapture cap_road(ROAD_CAMERA_ID, cv::CAP_V4L2); // road
-  cap_road.set(cv::CAP_PROP_FRAME_WIDTH, 853);
-  cap_road.set(cv::CAP_PROP_FRAME_HEIGHT, 480);
+  cap_road.set(cv::CAP_PROP_FRAME_WIDTH, 1280);
+  cap_road.set(cv::CAP_PROP_FRAME_HEIGHT, 720);
   cap_road.set(cv::CAP_PROP_FPS, s->fps);
   cap_road.set(cv::CAP_PROP_AUTOFOCUS, 0); // off
   cap_road.set(cv::CAP_PROP_FOCUS, 0); // 0 - 255?
   // cv::Rect roi_rear(160, 0, 960, 720);
 
   // transforms calculation see tools/webcam/warp_vis.py
-  float ts[9] = {1.50330396, 0.0, -59.40969163,
+  /*
+	float ts[9] = {1.50330396, 0.0, -59.40969163,
                   0.0, 1.50330396, 76.20704846,
+									0.0, 0.0, 1.0};
+									*/
+	//For c930 1920*1080
+	float ts[9] = { 0.61820652, 0.0,  186.34782609,
+                  0.0, 0.61820652, 214.44565217,
                   0.0, 0.0, 1.0};
   // if camera upside down:
   // float ts[9] = {-1.50330396, 0.0, 1223.4,

--- a/tools/webcam/warp_vis.py
+++ b/tools/webcam/warp_vis.py
@@ -5,7 +5,7 @@ import numpy as np
 eon_focal_length = 910.0  # pixels
 eon_dcam_focal_length = 860.0  # pixels
 
-webcam_focal_length = -908.0/1.5  # pixels
+webcam_focal_length = 2208.0/1.5  # pixels
 
 eon_intrinsics = np.array([
   [eon_focal_length,   0.,   1164/2.],
@@ -18,8 +18,8 @@ eon_dcam_intrinsics = np.array([
   [  0,    0,     1]])
 
 webcam_intrinsics = np.array([
-  [webcam_focal_length,   0.,   1280/2/1.5],
-  [  0.,  webcam_focal_length,  720/2/1.5],
+  [webcam_focal_length,   0.,   1920/2/1.5],
+  [  0.,  webcam_focal_length,  1080/2/1.5],
   [  0.,    0.,     1.]])
 
 if __name__ == "__main__":
@@ -29,15 +29,16 @@ if __name__ == "__main__":
   print("trans_webcam_to_eon_rear:\n", trans_webcam_to_eon_rear)
   print("trans_webcam_to_eon_front:\n", trans_webcam_to_eon_front)
 
-  cap = cv2.VideoCapture(1)
-  cap.set(cv2.CAP_PROP_FRAME_WIDTH, 853)
-  cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 480)
+  cap = cv2.VideoCapture(0)
+  cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
+  cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
+  cap.set(cv2.CAP_PROP_FOCUS, 100)
 
   while (True):
     ret, img = cap.read()
     if ret:
-      # img = cv2.warpPerspective(img, trans_webcam_to_eon_rear, (1164,874), borderMode=cv2.BORDER_CONSTANT, borderValue=0)
-      img = cv2.warpPerspective(img, trans_webcam_to_eon_front, (1164, 874), borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+      img = cv2.warpPerspective(img, trans_webcam_to_eon_rear, (1164,874), borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+			#img = cv2.warpPerspective(img, trans_webcam_to_eon_front, (1164, 874), borderMode=cv2.BORDER_CONSTANT, borderValue=0)
       print(img.shape, end='\r')
       cv2.imshow('preview', img)
       cv2.waitKey(10)


### PR DESCRIPTION
## Description 

Fixed webcam transformation to adjust webcam [Logitech c930](https://www.logitech.com/zh-tw/products/webcams/c930e-business-webcam.960-000976.html#specs). 

## Regulate
we can use `/tools/webcam/warp_vis.py` to calculate the transformation matrix for `opencv`. Adjust `webcam_focal_length` and width/height in `webcam_intrinsics` if the resolution of the view in openpilot ui is not as expected.  (c930 is 1920 * 1080) 
```
webcam_intrinsics = np.array([
 [webcam_focal_length,   0.,   1920/2/1.5],
 [  0.,  webcam_focal_length,  1080/2/1.5],
 [  0.,    0.,     1.]])
```
The result in this PR is :
```
trans_webcam_to_eon_rear:
 [[  0.61820652   0.         186.34782609]
 [  0.           0.61820652 214.44565217]
 [  0.           0.           1.        ]]
trans_webcam_to_eon_front:
 [[  0.58423913   0.         202.08695652]
 [  0.           0.58423913 221.67391304]
 [  0.           0.           1.        ]]
```
Rear is for road camera and front is for driver camera. The matrix `trans_webcam_to_eon_rear` is applied to `camera_webcam.cc`
